### PR TITLE
fix(RF42): Agregar detalles de preguntas en reportes de evaluación

### DIFF
--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -325,15 +325,15 @@ class Evaluacion(models.Model):
                 if respuesta.evaluacion_id.id != self.id:
                     continue
 
-                respuestas.append(respuesta.respuesta_texto)
+                respuestas.append(respuesta.respuesta_mostrar)
 
                 for i, respuesta_tabulada in enumerate(respuestas_tabuladas):
-                    if respuesta_tabulada["nombre"] == respuesta.respuesta_texto:
+                    if respuesta_tabulada["nombre"] == respuesta.respuesta_mostrar:
                         respuestas_tabuladas[i]["valor"] += 1
                         break
                 else:
                     respuestas_tabuladas.append(
-                        {"nombre": respuesta.respuesta_texto, "valor": 1}
+                        {"nombre": respuesta.respuesta_mostrar, "valor": 1}
                     )
 
             datos_pregunta = {
@@ -459,6 +459,7 @@ class Evaluacion(models.Model):
                 "generaciones": [{"nombre": nombre, "valor": conteo} for nombre, conteo in generaciones.items()],
                 "puestos": [{"nombre": nombre, "valor": conteo} for nombre, conteo in puestos.items()],
                 "generos": [{"nombre": nombre, "valor": conteo} for nombre, conteo in generos.items()],
+                "preguntas": self.action_generar_datos_reporte_generico()["preguntas"],
                 "final": final,
             }
 
@@ -468,6 +469,7 @@ class Evaluacion(models.Model):
                 "evaluacion": self,
                 "categorias": [categorias[nombre] for nombre in categorias_orden],
                 "dominios": [dominios[nombre] for nombre in dominios_orden],
+                "preguntas": self.action_generar_datos_reporte_generico()["preguntas"],
                 "final": final,
             }
 

--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -625,6 +625,7 @@ class Evaluacion(models.Model):
                 "generaciones": [{"nombre": nombre, "valor": conteo} for nombre, conteo in generaciones.items()],
                 "puestos": [{"nombre": nombre, "valor": conteo} for nombre, conteo in puestos.items()],
                 "generos": [{"nombre": nombre, "valor": conteo} for nombre, conteo in generos.items()],  
+                "preguntas": self.action_generar_datos_reporte_generico()["preguntas"],
             }
 
         else:
@@ -635,6 +636,7 @@ class Evaluacion(models.Model):
                 "total": total_puntuacion,
                 "total_maximo": total_maximo_posible,
                 "total_porcentaje": total_porcentaje,
+                "preguntas": self.action_generar_datos_reporte_generico()["preguntas"],
             }
 
         # Parámetros para el template

--- a/talent360/evaluaciones/views/evaluaciones_templates.xml
+++ b/talent360/evaluaciones/views/evaluaciones_templates.xml
@@ -26,9 +26,10 @@
         <template id="encuestas_reporte" name="Reporte: página de reporte genérico">
             <t t-call="evaluaciones.diseño">
                 <t t-set="limite_registros" t-value="10"/>
-                <div class="o_survey_result">
+                <div class="o_survey_result mb-5">
                     <t t-call="evaluaciones.encuestas_reporte_header" />
                     <t t-call="evaluaciones.encuestas_reporte_nom_035" />
+                    <t t-call="evaluaciones.encuestas_reporte_inner" />
                 </div>
             </t>
         </template>
@@ -55,6 +56,16 @@
                 <button class="btn btn-primary d-none d-print-none d-md-inline-block o_survey_results_print" aria-label="Print" title="Print">
                     <i class="fa fa-print"></i> Exportar
                 </button>
+            </div>
+        </template>
+
+        <template id="encuestas_reporte_inner" name="Reporte: contenido de reporte genérico">
+            <h4><button class="btn btn-link ps-0 pt-2 d-print-none" type="button" data-bs-toggle="collapse" t-attf-data-bs-target=".question_detail">
+                <i class="fa fa-eye" aria-hidden="true"/>
+            </button>Ver detalles de preguntas</h4>
+            <div class="question_detail survey_section container-fluid collapse show" t-foreach="preguntas" t-as='datos_pregunta'>
+                <t t-set="pregunta" t-value="datos_pregunta['pregunta']"/>
+                <div class="o_survey_results_question_wrapper container-fluid p-5" t-call="evaluaciones.encuestas_reporte_pregunta" />
             </div>
         </template>
 
@@ -268,7 +279,7 @@
                     </t>
                 </div>
             </div>
-            <div class="survey_section mb-5">
+            <div class="survey_section">
                 <h4>Necesidad de acción</h4>
                 <span class="container-fluid">
                     <t t-if="final &lt; 20">El riesgo resulta despreciable por lo que no se requiere medidas adicionales.</t>
@@ -511,21 +522,10 @@
                         <span>Gráfico de barras</span>
                     </a>
                 </li>
-                <li t-if="pregunta_contestada" class="nav-item">
-                    <a t-att-href="'#grafica_columnas_pregunta__%d' % pregunta.id" t-att-aria-controls="'grafica_columnas_pregunta__%d' % pregunta.id" class="nav-link" data-bs-toggle="tab" role="tab" data-chart="1">
-                        <i class="fa fa-bar-chart-o"></i>
-                        <span>Gráfico de columnas</span>
-                    </a>
-                </li>
-                <li t-if="pregunta_contestada" class="nav-item">
-                    <a t-att-href="'#grafica_pastel_pregunta__%d' % pregunta.id" t-att-aria-controls="'grafica_pastel_pregunta__%d' % pregunta.id" class="nav-link" data-bs-toggle="tab" role="tab" data-chart="1">
-                        <i class="fa fa-bar-chart-o"></i>
-                        <span>Gráfico de pastel</span>
-                    </a>
-                </li>
                 <li class="nav-item">
                     <a t-att-href="'#datos_pregunta__%d' % pregunta.id" t-att-aria-controls="'datos_pregunta__%d' % pregunta.id" t-attf-class="nav-link #{'active' if not pregunta_contestada else ''}" data-bs-toggle="tab" role="tab">
                         <i class="fa fa-list-alt me-1"/>
+                        <span>Tabla de datos</span>
                     </a>
                 </li>
             </ul>
@@ -552,14 +552,14 @@
                             <tr t-foreach="respuestas_tabuladas" t-as="respuesta">
                                 <td>
                                     <p>
-                                        <span t-esc="respuesta['texto']"/>
+                                        <span t-esc="respuesta['nombre']"/>
                                     </p>
                                 </td>
                                 <td class="o_survey_answer">
-                                    <span t-esc="round(respuesta['conteo'] * 100.0/ (len(respuestas) or 1), 2)"></span> % 
+                                    <span t-esc="round(respuesta['valor'] * 100.0/ (len(respuestas) or 1), 2)"></span> % 
                                 </td>
                                 <td class="o_survey_answer">
-                                    <span t-esc="'%s Votos' % respuesta['conteo']" class="badge text-bg-primary"/>
+                                    <span t-esc="'%s Votos' % respuesta['valor']" class="badge text-bg-primary"/>
                                 </td>
                             </tr>
                         </tbody>

--- a/talent360/evaluaciones/views/evaluaciones_templates.xml
+++ b/talent360/evaluaciones/views/evaluaciones_templates.xml
@@ -40,6 +40,7 @@
                 <div class="o_survey_result">
                     <t t-call="evaluaciones.encuestas_reporte_header" />
                     <t t-call="evaluaciones.encuesta_reporte_clima" />
+                    <t t-call="evaluaciones.encuestas_reporte_inner" />
                 </div>
             </t>
         </template>


### PR DESCRIPTION
Fix Defect #138

En los reportes de evaluación, se añadió la sección de detalle de cada pregunta de la evaluación. Hay un botón que colapsa los detalles. 

![image](https://github.com/Black-Dot-2024/cr-blackdot/assets/110949367/4a4897b6-505e-4a74-b39a-8c16fb5792a7)
![image](https://github.com/Black-Dot-2024/cr-blackdot/assets/110949367/6be8c5f0-ca93-4ec3-850c-818c68779bd8)
