### PR TITLE
fix: limitar a 5 mil usuarios externos

### DIFF
--- a/talent360/evaluaciones/wizards/asignar_usuarios_exernos_wizard.py
+++ b/talent360/evaluaciones/wizards/asignar_usuarios_exernos_wizard.py
@@ -55,6 +55,10 @@ class AsignarUsuariosExternosWizard(models.TransientModel):
         self.validar_columnas(csv_lector.fieldnames)
 
         for i, fila in enumerate(csv_lector):
+            if i >= 50000: 
+                raise exceptions.ValidationError(
+                    _("Error: No se pueden cargar más de 50,000 usuarios.")
+                )
             try:
                 fecha_ingreso = datetime.strptime(fila["Fecha de ingreso"], "%d/%m/%Y").date()
                 fecha_nacimiento = datetime.strptime(fila["Fecha de nacimiento"], "%d/%m/%Y").date()


### PR DESCRIPTION
#Defect #247

### Descripción
50000 usuario máximo en la carga de usuarios

### Cambios realizados

- En talent360/evaluaciones/wizards/asignar_usuarios_exernos_wizard.py agregar limitación a 50000 líneas del csv para limitar al 50000 usuarios y agregar mensaje cuando se pasa de estos.

![image](https://github.com/Black-Dot-2024/cr-blackdot/assets/105958620/5c23aa09-0e8c-4610-bde5-7900365199b2)


