### PR TITLE
Feat/rf46 filtrar reportes clima

### DIFF
--- a/talent360/evaluaciones/controllers/evaluaciones.py
+++ b/talent360/evaluaciones/controllers/evaluaciones.py
@@ -1,12 +1,7 @@
 from odoo import http, _
 from odoo.http import request
 from odoo.exceptions import AccessError
-from ..models.evaluacion import Evaluacion
-from ..models.respuesta import Respuesta as respuesta
-from ..models.pregunta import Pregunta as pregunta
 import json
-from ..models.usuario_evaluacion_rel import UsuarioEvaluacionRel as usuario_evaluacion
-import time
 import werkzeug
 
 
@@ -16,28 +11,45 @@ class EvaluacionesController(http.Controller):
     @http.route(
         "/evaluacion/reporte/<model('evaluacion'):evaluacion>", type="http", auth="user"
     )
-    def reporte_controller(self, evaluacion: Evaluacion):
+    def reporte_controller(self, evaluacion, filtros=None):
         """Método para generar y mostrar un reporte de evaluación.
         Este método verifica que el usuario tenga los permisos necesario, obtiene los datos
         del modelo de evaluaciones y renderiza el reporte con esos datos.
 
+        :param evaluacion: objeto de la evaluación a generar el reporte
+        :param filtros: filtros a aplicar al reporte
+
         :return: html renderizado del template con los datos del reporte
         """
 
+        # Verificar permisos de usuario
         if not request.env.user.has_group(
             "evaluaciones.evaluaciones_cliente_cr_group_user"
         ):
             raise AccessError(_("No tienes permitido acceder a este recurso."))
 
-        parametros = evaluacion.generar_datos_reporte_NOM_035_action()
-        parametros["preguntas"] = evaluacion.generar_datos_reporte_generico_action()[
-            "preguntas"
-        ]
+        # Parsear filtros
+        if filtros:
+            filtros = json.loads(filtros)
+            filtros = {categoria: valores for categoria, valores in filtros.items() if valores}
+
+        parametros = {
+            "preguntas": evaluacion.generar_datos_reporte_generico_action(filtros)["preguntas"]
+        }
 
         if evaluacion.incluir_demograficos:
-            parametros.update(evaluacion.generar_datos_demograficos())
+            parametros.update(evaluacion.generar_datos_demograficos(filtros))
 
-        return request.render("evaluaciones.encuestas_reporte", parametros)
+        if evaluacion.tipo == "NOM_035":
+            parametros.update(evaluacion.generar_datos_reporte_NOM_035_action())
+            return request.render("evaluaciones.encuestas_reporte_nom_035", parametros)
+
+        elif evaluacion.tipo == "CLIMA":
+            parametros.update(evaluacion.generar_datos_reporte_clima_action(filtros))
+            return request.render("evaluaciones.encuestas_reporte_clima", parametros)
+
+        else:
+            raise ValueError(_("Tipo de evaluación no soportado para reporte."))
 
     @http.route(
         "/evaluacion/responder/<int:evaluacion_id>/<string:token>",
@@ -227,30 +239,3 @@ class EvaluacionesController(http.Controller):
             usuario_eva_mod.sudo().action_update_estado(None, evaluacion_id, token)
 
         return werkzeug.utils.redirect("/evaluacion/contestada")
-
-    @http.route(
-        "/evaluacion/reporte-clima/<model('evaluacion'):evaluacion>",
-        type="http",
-        auth="user",
-    )
-    def reporte_clima_controller(self, evaluacion: Evaluacion):
-        """Método para generar y mostrar el reporte de clima laboral.
-        :return: HTML renderizado del template con los datos del reporte.
-        """
-
-        # Verificar permisos de usuario
-        if not request.env.user.has_group(
-            "evaluaciones.evaluaciones_cliente_cr_group_user"
-        ):
-            raise AccessError(_("No tienes permitido acceder a este recurso."))
-
-        # Generar parámetros para el reporte
-        parametros = evaluacion.generar_datos_reporte_clima_action()
-        parametros["preguntas"] = evaluacion.generar_datos_reporte_generico_action()[
-            "preguntas"
-        ]
-
-        if evaluacion.incluir_demograficos:
-            parametros.update(evaluacion.generar_datos_demograficos())
-
-        return request.render("evaluaciones.encuestas_reporte_clima", parametros)

--- a/talent360/evaluaciones/controllers/evaluaciones.py
+++ b/talent360/evaluaciones/controllers/evaluaciones.py
@@ -31,10 +31,14 @@ class EvaluacionesController(http.Controller):
         # Parsear filtros
         if filtros:
             filtros = json.loads(filtros)
-            filtros = {categoria: valores for categoria, valores in filtros.items() if valores}
+            filtros = {
+                categoria: valores for categoria, valores in filtros.items() if valores
+            }
 
         parametros = {
-            "preguntas": evaluacion.generar_datos_reporte_generico_action(filtros)["preguntas"]
+            "preguntas": evaluacion.generar_datos_reporte_generico_action(filtros)[
+                "preguntas"
+            ]
         }
 
         if evaluacion.incluir_demograficos:

--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -344,7 +344,7 @@ class Evaluacion(models.Model):
         """
         Genera filtros para el reporte de la evaluación.
 
-        Esta función genera filtros para el reporte de la evaluación actual 
+        Esta función genera filtros para el reporte de la evaluación actual
         y sigue con el proceso de renderización del reporte.
 
         :return: una acción de redirección al modal creación de filtros
@@ -612,7 +612,7 @@ class Evaluacion(models.Model):
                     )
                 else:
                     nombre_departamento = "Sin Usuario"
-                
+
                 departamento = next(
                     (
                         dept
@@ -680,7 +680,7 @@ class Evaluacion(models.Model):
 
         :return: True si la respuesta cumple con los filtros, False en caso contrario.
         """
-        
+
         if not filtros:
             return True
 

--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -334,24 +334,71 @@ class Evaluacion(models.Model):
 
         """
 
-        url_base = "/evaluacion/reporte/"
-        if self.tipo == "CLIMA":
-            url_base = "/evaluacion/reporte-clima/"
-        else:
-            url_base = "/evaluacion/reporte/"
-
         return {
             "type": "ir.actions.act_url",
-            "url": f"{url_base}{self.id}",
+            "url": f"/evaluacion/reporte/{self.id}",
             "target": "new",
         }
 
-    def generar_datos_reporte_generico_action(self):
+    def filtros_reporte_action(self):
+        """
+        Genera filtros para el reporte de la evaluación.
+
+        Esta función genera filtros para el reporte de la evaluación actual 
+        y sigue con el proceso de renderización del reporte.
+
+        :return: una acción de redirección al modal creación de filtros
+        """
+
+        datos_demograficos = self.generar_datos_demograficos()
+
+        categorias = [
+            ("Departamento", "departamentos", "departamento"),
+            ("Generación", "generaciones", "generacion"),
+            ("Puesto", "puestos", "puesto"),
+            ("Género", "generos", "genero"),
+        ]
+
+        filtros = [
+            {
+                "categoria": categoria,
+                "categoria_interna": nombre_individual,
+                "filtro_seleccion_ids": [
+                    (0, 0, {"texto": dep["nombre"], "categoria": categoria})
+                    for dep in datos_demograficos[nombre_grupal]
+                ],
+            }
+            for categoria, nombre_grupal, nombre_individual in categorias
+        ]
+
+        filtros_ids = self.env["filtro.wizard"].create(filtros)
+
+        # Se añade filtro?original id a slecciones
+        for filtro in filtros_ids:
+            filtro.filtro_seleccion_ids.write({"filtro_original_id": filtro.id})
+
+        filtros_wizard = self.env["crear.filtros.wizard"].create(
+            {"filtros_ids": [(6, 0, filtros_ids.ids)]}
+        )
+
+        return {
+            "name": "Crear filtros",
+            "type": "ir.actions.act_window",
+            "res_model": "crear.filtros.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "res_id": filtros_wizard.id,
+            "context": {"actual_evaluacion_id": self.id},
+        }
+
+    def generar_datos_reporte_generico_action(self, filtros=None):
         """
         Genera los datos necesarios para el reporte genérico de la evaluación.
 
         Esta función genera los parámetros requeridos para generar un reporte genérico de la evaluación actual,
         incluyendo las preguntas y las respuestas tabuladas.
+
+        :param filtros: Los filtros a aplicar al reporte.
 
         :return: Los parámetros necesarios para generar el reporte.
 
@@ -369,6 +416,10 @@ class Evaluacion(models.Model):
                     ("evaluacion_id.id", "=", self.id),
                 ]
             )
+            if filtros:
+                respuesta_ids = respuesta_ids.filtered(
+                    lambda r: self.validar_filtro(filtros, r)
+                )
 
             respuestas = [respuesta.respuesta_mostrar for respuesta in respuesta_ids]
             respuestas_tabuladas = dict(Counter(respuestas))
@@ -471,10 +522,12 @@ class Evaluacion(models.Model):
 
         return parametros
 
-    def generar_datos_reporte_clima_action(self):
+    def generar_datos_reporte_clima_action(self, filtros=None):
         """
         Genera los datos necesarios para el reporte de clima organizacional de la evaluación.
         Calcula el porcentaje de satisfacción para cada categoría y departamento.
+
+        :param filtros: Los filtros a aplicar al reporte.
 
         :return: Los parámetros necesarios para generar el reporte.
         """
@@ -535,18 +588,31 @@ class Evaluacion(models.Model):
             maximo_pregunta = 0
 
             for respuesta in pregunta.respuesta_ids:
+                if not self.validar_filtro(filtros, respuesta):
+                    continue
+
                 valor_respuesta = respuesta.valor_respuesta
                 valor_pregunta += valor_respuesta
-                maximo_pregunta += (
-                    pregunta._calculate_valor_maximo()
-                )  # Suponiendo un máximo de 4 para cada respuesta en escala
-                # Suponiendo un máximo de 4 para cada respuesta en escala
+                maximo_pregunta += pregunta._calculate_valor_maximo()
 
-                nombre_departamento = (
-                    respuesta.usuario_id.department_id.name
-                    if respuesta.usuario_id.department_id
-                    else "Sin departamento"
-                )
+                if respuesta.usuario_id:
+                    nombre_departamento = (
+                        respuesta.usuario_id.department_id.name
+                        if respuesta.usuario_id.department_id
+                        else "Sin departamento"
+                    )
+                elif respuesta.usuario_externo_id:
+                    usuario_externo = self.env["usuario.externo"].browse(
+                        respuesta.usuario_externo_id
+                    )
+                    nombre_departamento = (
+                        usuario_externo.direccion
+                        if usuario_externo.direccion
+                        else "Sin departamento"
+                    )
+                else:
+                    nombre_departamento = "Sin Usuario"
+                
                 departamento = next(
                     (
                         dept
@@ -565,7 +631,7 @@ class Evaluacion(models.Model):
                     categoria_actual["departamentos"].append(departamento)
 
                 departamento["puntos"] += valor_respuesta
-                departamento["puntos_maximos"] += 4
+                departamento["puntos_maximos"] += pregunta._calculate_valor_maximo()
 
             total_puntuacion += valor_pregunta
             total_maximo_posible += maximo_pregunta
@@ -604,7 +670,42 @@ class Evaluacion(models.Model):
 
         return parametros
 
-    def generar_datos_demograficos(self):
+    def validar_filtro(self, filtros, respuesta=None, datos_demograficos=None):
+        """
+        Valida si una respuesta cumple con los filtros especificados.
+
+        :param filtros: Los filtros a aplicar.
+        :param respuesta: La respuesta a validar.
+        :param datos_demograficos: Los datos demográficos del usuario.
+
+        :return: True si la respuesta cumple con los filtros, False en caso contrario.
+        """
+        
+        if not datos_demograficos:
+            if not respuesta:
+                return False
+
+            if respuesta.usuario_id:
+                datos_demograficos = self.obtener_datos_demograficos(
+                    respuesta.usuario_id
+                )
+            elif respuesta.usuario_externo_id:
+                usuario_externo = self.env["usuario.externo"].browse(
+                    respuesta.usuario_externo_id
+                )
+                datos_demograficos = self.obtener_datos_demograficos_externos(
+                    usuario_externo
+                )
+            else:
+                return False
+
+        for categoria, valores in filtros.items():
+            if not datos_demograficos[categoria] in valores:
+                return False
+
+        return True
+
+    def generar_datos_demograficos(self, filtros=None):
         """
         Genera los datos demográficos de la evaluación.
 
@@ -621,7 +722,13 @@ class Evaluacion(models.Model):
         )
 
         for usuario in usuario_evaluacion.mapped("usuario_id"):
-            datos_demograficos.append(self.obtener_datos_demograficos(usuario))
+            datos_demograficos_usuario = self.obtener_datos_demograficos(usuario)
+            if filtros and not self.validar_filtro(
+                filtros, datos_demograficos=datos_demograficos_usuario
+            ):
+                continue
+
+            datos_demograficos.append(datos_demograficos_usuario)
 
         usuario_evaluacion_externo = self.env["usuario.evaluacion.rel"].search(
             [
@@ -632,9 +739,15 @@ class Evaluacion(models.Model):
         )
 
         for usuario_externo in usuario_evaluacion_externo.mapped("usuario_externo_id"):
-            datos_demograficos.append(
-                self.obtener_datos_demograficos_externos(usuario_externo)
+            datos_demograficos_usuario = self.obtener_datos_demograficos_externos(
+                usuario_externo
             )
+            if filtros and not self.validar_filtro(
+                filtros, datos_demograficos=datos_demograficos_usuario
+            ):
+                continue
+
+            datos_demograficos.append(datos_demograficos_usuario)
 
         departamentos = defaultdict(int)
         generaciones = defaultdict(int)

--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -588,7 +588,7 @@ class Evaluacion(models.Model):
             maximo_pregunta = 0
 
             for respuesta in pregunta.respuesta_ids:
-                if not self.validar_filtro(filtros, respuesta):
+                if filtros and not self.validar_filtro(filtros, respuesta):
                     continue
 
                 valor_respuesta = respuesta.valor_respuesta
@@ -681,6 +681,9 @@ class Evaluacion(models.Model):
         :return: True si la respuesta cumple con los filtros, False en caso contrario.
         """
         
+        if not filtros:
+            return True
+
         if not datos_demograficos:
             if not respuesta:
                 return False

--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -336,7 +336,7 @@ class Evaluacion(models.Model):
 
         if self.porcentaje_respuestas <= 0:
             raise exceptions.ValidationError(_(
-                "No se pueden generar filtros para una evaluación sin respuestas."
+                "No se puede generar un reporte para una evaluación sin respuestas."
             ))
 
         return {
@@ -358,7 +358,7 @@ class Evaluacion(models.Model):
         # Validar si existen respuestas
         if self.porcentaje_respuestas <= 0:
             raise exceptions.ValidationError(_(
-                "No se pueden generar filtros para una evaluación sin respuestas."
+                "No se puede generar un reporte para una evaluación sin respuestas."
             ))
 
         datos_demograficos = self.generar_datos_demograficos()

--- a/talent360/evaluaciones/models/evaluacion.py
+++ b/talent360/evaluaciones/models/evaluacion.py
@@ -335,9 +335,9 @@ class Evaluacion(models.Model):
         """
 
         if self.porcentaje_respuestas <= 0:
-            raise exceptions.ValidationError(
+            raise exceptions.ValidationError(_(
                 "No se pueden generar filtros para una evaluación sin respuestas."
-            )
+            ))
 
         return {
             "type": "ir.actions.act_url",
@@ -357,9 +357,9 @@ class Evaluacion(models.Model):
 
         # Validar si existen respuestas
         if self.porcentaje_respuestas <= 0:
-            raise exceptions.ValidationError(
+            raise exceptions.ValidationError(_(
                 "No se pueden generar filtros para una evaluación sin respuestas."
-            )
+            ))
 
         datos_demograficos = self.generar_datos_demograficos()
 

--- a/talent360/evaluaciones/models/pregunta.py
+++ b/talent360/evaluaciones/models/pregunta.py
@@ -101,7 +101,7 @@ class Pregunta(models.Model):
         Returns:
             Parámetros necesarios para abrir la vista gráfica de las respuestas.
         """
-        evaluacion_id = self._context.get("current_evaluacion_id")
+        evaluacion_id = self._context.get("actual_evaluacion_id")
         # Redirect to graph view of respuestas filtered by evaluacion_id and pregunta_id grouped by respuesta
         return {
             "type": "ir.actions.act_window",

--- a/talent360/evaluaciones/models/res_users.py
+++ b/talent360/evaluaciones/models/res_users.py
@@ -29,7 +29,7 @@ class Users(models.Model):
             Parámetros necesarios para abrir la vista gráfica de las respuestas.
         """
 
-        evaluacion_id = self._context.get("current_evaluacion_id")
+        evaluacion_id = self._context.get("actual_evaluacion_id")
         respuesta_ids = self.env["respuesta"].search(
             [
                 ("evaluacion_id.id", "=", evaluacion_id),

--- a/talent360/evaluaciones/models/respuesta.py
+++ b/talent360/evaluaciones/models/respuesta.py
@@ -23,7 +23,9 @@ class Respuesta(models.Model):
 
     pregunta_id = fields.Many2one("pregunta", string="Preguntas")
     usuario_id = fields.Many2one("res.users", string="Usuario")
-    usuario_externo_id = fields.Integer(string="Usuario externo", compute="_compute_usuario_externo_id")
+    usuario_externo_id = fields.Integer(
+        string="Usuario externo", compute="_compute_usuario_externo_id"
+    )
     evaluacion_id = fields.Many2one("evaluacion", string="Evaluacion")
     pregunta_texto = fields.Char(related="pregunta_id.pregunta_texto")
     respuesta_texto = fields.Char("Respuesta")
@@ -173,6 +175,8 @@ class Respuesta(models.Model):
                 ]
             )
             if usuario_evaluacion_rel.usuario_externo_id:
-                registro.usuario_externo_id = usuario_evaluacion_rel.usuario_externo_id.id
+                registro.usuario_externo_id = (
+                    usuario_evaluacion_rel.usuario_externo_id.id
+                )
             else:
                 registro.usuario_externo_id = False

--- a/talent360/evaluaciones/models/respuesta.py
+++ b/talent360/evaluaciones/models/respuesta.py
@@ -23,6 +23,7 @@ class Respuesta(models.Model):
 
     pregunta_id = fields.Many2one("pregunta", string="Preguntas")
     usuario_id = fields.Many2one("res.users", string="Usuario")
+    usuario_externo_id = fields.Integer(string="Usuario externo", compute="_compute_usuario_externo_id")
     evaluacion_id = fields.Many2one("evaluacion", string="Evaluacion")
     pregunta_texto = fields.Char(related="pregunta_id.pregunta_texto")
     respuesta_texto = fields.Char("Respuesta")
@@ -156,3 +157,22 @@ class Respuesta(models.Model):
                 registro.valor_respuesta = registro.opcion_id.valor
             else:
                 registro.valor_respuesta = 0
+
+    def _compute_usuario_externo_id(self):
+        """
+        Método para calcular el identificador del usuario externo.
+
+        :return: Identificador del usuario externo
+        """
+
+        for registro in self:
+            usuario_evaluacion_rel = self.env["usuario.evaluacion.rel"].search(
+                [
+                    ("token", "=", registro.token),
+                    ("evaluacion_id", "=", registro.evaluacion_id.id),
+                ]
+            )
+            if usuario_evaluacion_rel.usuario_externo_id:
+                registro.usuario_externo_id = usuario_evaluacion_rel.usuario_externo_id.id
+            else:
+                registro.usuario_externo_id = False

--- a/talent360/evaluaciones/models/usuario_externo.py
+++ b/talent360/evaluaciones/models/usuario_externo.py
@@ -51,7 +51,7 @@ class UsuarioExterno(models.Model):
         Esta función busca las respuestas de un usuario externo para una evaluación específica. Si encuentra respuestas, muestra una ventana con las respuestas del usuario. Si no encuentra respuestas o si el usuario está asignado a la evaluación varias veces, lanza un error.
         """
 
-        evaluacion_id = self._context.get("current_evaluacion_id")
+        evaluacion_id = self._context.get("actual_evaluacion_id")
 
         usuario_evaluacion_rel = self.env["usuario.evaluacion.rel"].search(
             [

--- a/talent360/evaluaciones/models/usuario_externo.py
+++ b/talent360/evaluaciones/models/usuario_externo.py
@@ -26,7 +26,7 @@ class UsuarioExterno(models.Model):
     _description = "Usuarios externos a la plataforma. Se utiliza para que puedan responer encuestas sin tener un usuario"
     _rec_name = "nombre"
 
-    nombre = fields.Char(string="Nombre", required=True)
+    nombre = fields.Char(required=True)
     email = fields.Char(string="Correo electrónico", required=True)
     puesto = fields.Char()
     nivel_jerarquico = fields.Char(string="Nivel jerárquico")

--- a/talent360/evaluaciones/security/ir.model.access.csv
+++ b/talent360/evaluaciones/security/ir.model.access.csv
@@ -23,6 +23,6 @@
 "access_asignar_usuario_externo_wizard_colaborador_cr","access.asignar.usuario.externo.wizard","model_asignar_usuario_externo_wizard","evaluaciones.evaluaciones_colaborador_cr_group_user",1,1,1,1
 "access_usuario_externo_cliente_cr","access.usuario.externo","model_usuario_externo","evaluaciones.evaluaciones_cliente_cr_group_user",1,1,1,1
 "access_usuario_externo_colaborador_cr","access.usuario.externo","model_usuario_externo","evaluaciones.evaluaciones_colaborador_cr_group_user",1,1,1,1
-"access_filtro_wizard_colaborador_cr","access.filtro.wizard","model_filtro_wizard","base.group_user",1,1,1,1
-"access_crear_filtros_wizard_colaborador_cr","access.crear.filtros.wizard","model_crear_filtros_wizard","base.group_user",1,1,1,1
-"access_filtro_seleccion_wizard_colaborador_cr","access.filtro.seleccion.wizard","model_filtro_seleccion_wizard","base.group_user",1,1,1,1
+"access_filtro_wizard_cliente_cr","access.filtro.wizard","model_filtro_wizard","evaluaciones.evaluaciones_cliente_cr_group_user",1,1,1,1
+"access_crear_filtros_wizard_cliente_cr","access.crear.filtros.wizard","model_crear_filtros_wizard","evaluaciones.evaluaciones_cliente_cr_group_user",1,1,1,1
+"access_filtro_seleccion_wizard_cliente_cr","access.filtro.seleccion.wizard","model_filtro_seleccion_wizard","evaluaciones.evaluaciones_cliente_cr_group_user",1,1,1,1

--- a/talent360/evaluaciones/security/ir.model.access.csv
+++ b/talent360/evaluaciones/security/ir.model.access.csv
@@ -23,3 +23,6 @@
 "access_asignar_usuario_externo_wizard_colaborador_cr","access.asignar.usuario.externo.wizard","model_asignar_usuario_externo_wizard","evaluaciones.evaluaciones_colaborador_cr_group_user",1,1,1,1
 "access_usuario_externo_cliente_cr","access.usuario.externo","model_usuario_externo","evaluaciones.evaluaciones_cliente_cr_group_user",1,1,1,1
 "access_usuario_externo_colaborador_cr","access.usuario.externo","model_usuario_externo","evaluaciones.evaluaciones_colaborador_cr_group_user",1,1,1,1
+"access_filtro_wizard_colaborador_cr","access.filtro.wizard","model_filtro_wizard","base.group_user",1,1,1,1
+"access_crear_filtros_wizard_colaborador_cr","access.crear.filtros.wizard","model_crear_filtros_wizard","base.group_user",1,1,1,1
+"access_filtro_seleccion_wizard_colaborador_cr","access.filtro.seleccion.wizard","model_filtro_seleccion_wizard","base.group_user",1,1,1,1

--- a/talent360/evaluaciones/tests/test_crear_evaluacion_360.py
+++ b/talent360/evaluaciones/tests/test_crear_evaluacion_360.py
@@ -15,7 +15,7 @@ class TestCrearEvaluacion360(TransactionCase):
                 "tipo": "competencia",
                 "tipo_competencia": "90",
                 "estado": "borrador",
-                "fecha_inicio": datetime.today() ,
+                "fecha_inicio": datetime.today(),
                 "fecha_final": datetime.today(),
             }
         )

--- a/talent360/evaluaciones/tests/test_crear_evaluacion_360.py
+++ b/talent360/evaluaciones/tests/test_crear_evaluacion_360.py
@@ -1,4 +1,5 @@
 from odoo.tests.common import TransactionCase
+from datetime import datetime
 
 
 class TestCrearEvaluacion360(TransactionCase):
@@ -14,8 +15,8 @@ class TestCrearEvaluacion360(TransactionCase):
                 "tipo": "competencia",
                 "tipo_competencia": "90",
                 "estado": "borrador",
-                "fecha_inicio": "2021-01-01",
-                "fecha_final": "2021-01-31",
+                "fecha_inicio": datetime.today() ,
+                "fecha_final": datetime.today(),
             }
         )
 

--- a/talent360/evaluaciones/tests/test_evaluacion.py
+++ b/talent360/evaluaciones/tests/test_evaluacion.py
@@ -1,5 +1,5 @@
 from odoo.tests.common import TransactionCase
-
+from datetime import datetime
 
 class test_evaluacion(TransactionCase):
     """
@@ -24,8 +24,8 @@ class test_evaluacion(TransactionCase):
             {
                 "nombre": nombre,
                 "estado": estado,
-                "fecha_inicio": "2021-01-01",
-                "fecha_final": "2021-01-31",
+                "fecha_inicio": datetime.today() ,
+                "fecha_final": datetime.today(),
             }
         )
 

--- a/talent360/evaluaciones/tests/test_evaluacion.py
+++ b/talent360/evaluaciones/tests/test_evaluacion.py
@@ -1,6 +1,7 @@
 from odoo.tests.common import TransactionCase
 from datetime import datetime
 
+
 class test_evaluacion(TransactionCase):
     """
     Caso de prueba para evaluar la funcionalidades relacionada con evaluaciones en Odoo.
@@ -24,7 +25,7 @@ class test_evaluacion(TransactionCase):
             {
                 "nombre": nombre,
                 "estado": estado,
-                "fecha_inicio": datetime.today() ,
+                "fecha_inicio": datetime.today(),
                 "fecha_final": datetime.today(),
             }
         )

--- a/talent360/evaluaciones/tests/test_reportes.py
+++ b/talent360/evaluaciones/tests/test_reportes.py
@@ -52,7 +52,7 @@ class TestReportes(TransactionCase):
                 "nombre": "Evaluacion de prueba",
                 "estado": "borrador",
                 "tipo": "CLIMA",
-                "fecha_inicio": datetime.today() ,
+                "fecha_inicio": datetime.today(),
                 "fecha_final": datetime.today(),
             }
         )
@@ -477,7 +477,6 @@ class TestReportes(TransactionCase):
             ],
         )
 
-
     def test_validar_filtro(self):
         """
         Prueba la validación de un filtro.
@@ -492,17 +491,31 @@ class TestReportes(TransactionCase):
             "generacion": "Millennials",
         }
 
-        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"]}, datos_demograficos=datos_demograficos)
+        filtro = self.evaluacion.validar_filtro(
+            {"departamento": ["Test Department"]}, datos_demograficos=datos_demograficos
+        )
         self.assertEqual(filtro, True)
 
-        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"], "puesto": ["Test Employee"]}, datos_demograficos=datos_demograficos)
+        filtro = self.evaluacion.validar_filtro(
+            {"departamento": ["Test Department"], "puesto": ["Test Employee"]},
+            datos_demograficos=datos_demograficos,
+        )
         self.assertEqual(filtro, True)
 
-        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"], "puesto": ["Test Employee"]}, datos_demograficos=datos_demograficos)
+        filtro = self.evaluacion.validar_filtro(
+            {"departamento": ["Test Department"], "puesto": ["Test Employee"]},
+            datos_demograficos=datos_demograficos,
+        )
         self.assertEqual(filtro, True)
 
-        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"], "puesto": ["No valido"]}, datos_demograficos=datos_demograficos)
+        filtro = self.evaluacion.validar_filtro(
+            {"departamento": ["Test Department"], "puesto": ["No valido"]},
+            datos_demograficos=datos_demograficos,
+        )
         self.assertEqual(filtro, False)
 
-        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department", "Otro departamento"]}, datos_demograficos=datos_demograficos)
+        filtro = self.evaluacion.validar_filtro(
+            {"departamento": ["Test Department", "Otro departamento"]},
+            datos_demograficos=datos_demograficos,
+        )
         self.assertEqual(filtro, True)

--- a/talent360/evaluaciones/tests/test_reportes.py
+++ b/talent360/evaluaciones/tests/test_reportes.py
@@ -1,4 +1,5 @@
 from odoo.tests.common import TransactionCase
+from datetime import datetime
 
 
 class TestReportes(TransactionCase):
@@ -51,8 +52,8 @@ class TestReportes(TransactionCase):
                 "nombre": "Evaluacion de prueba",
                 "estado": "borrador",
                 "tipo": "CLIMA",
-                "fecha_inicio": "2021-01-01",
-                "fecha_final": "2021-01-31",
+                "fecha_inicio": datetime.today() ,
+                "fecha_final": datetime.today(),
             }
         )
 

--- a/talent360/evaluaciones/tests/test_reportes.py
+++ b/talent360/evaluaciones/tests/test_reportes.py
@@ -476,3 +476,33 @@ class TestReportes(TransactionCase):
                 {"nombre": "3", "valor": 4},
             ],
         )
+
+
+    def test_validar_filtro(self):
+        """
+        Prueba la validación de un filtro.
+
+        Este método verifica que el filtro sea válido.
+        """
+
+        datos_demograficos = {
+            "departamento": "Test Department",
+            "puesto": "Test Employee",
+            "genero": "Masculino",
+            "generacion": "Millennials",
+        }
+
+        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"]}, datos_demograficos=datos_demograficos)
+        self.assertEqual(filtro, True)
+
+        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"], "puesto": ["Test Employee"]}, datos_demograficos=datos_demograficos)
+        self.assertEqual(filtro, True)
+
+        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"], "puesto": ["Test Employee"]}, datos_demograficos=datos_demograficos)
+        self.assertEqual(filtro, True)
+
+        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department"], "puesto": ["No valido"]}, datos_demograficos=datos_demograficos)
+        self.assertEqual(filtro, False)
+
+        filtro = self.evaluacion.validar_filtro({"departamento": ["Test Department", "Otro departamento"]}, datos_demograficos=datos_demograficos)
+        self.assertEqual(filtro, True)

--- a/talent360/evaluaciones/views/asignar_usuarios_externos_template.xml
+++ b/talent360/evaluaciones/views/asignar_usuarios_externos_template.xml
@@ -22,4 +22,23 @@
             </form>
         </field>
     </record>
+
+    <record id="view_crear_filtros_wizard" model="ir.ui.view">
+        <field name="name">crear.filtros.wizard.form</field>
+        <field name="model">crear.filtros.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Crear Filtros">
+                <field name="filtros_ids">
+                    <tree string="Filtros" editable="bottom" create="false" delete="false" edit="true">
+                        <field name="categoria"/>
+                        <field name="filtro_seleccion_ids" widget="many2many_tags" domain="[('categoria', '=', categoria), ('filtro_original_id', '=', active_id)]" options="{'no_quick_create':True,'no_create_edit':True}"/>
+                    </tree>
+                </field>
+                <footer>
+                    <button string="Continuar" class="btn-primary" name="generar_reporte" type="object"/>
+                    <button string="Cancelar" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
 </odoo>

--- a/talent360/evaluaciones/views/crear_evaluacion_clima.xml
+++ b/talent360/evaluaciones/views/crear_evaluacion_clima.xml
@@ -45,14 +45,14 @@
                                 </field>
                             </page>
                             <page string="Asignados">
-                                <field class="lh-lg w-100" colspan="2" name="usuario_ids" nolabel="1" context="{'current_evaluacion_id': active_id}">
+                                <field class="lh-lg w-100" colspan="2" name="usuario_ids" nolabel="1" context="{'actual_evaluacion_id': active_id}">
                                     <tree editable="bottom">
                                         <field class="lh-m" name="name" readonly="1"/>
                                     </tree>
                                 </field>
                             </page>
                             <page string="Asignados Externos">
-                                <field class="lh-lg w-100" colspan="2" name="usuario_externo_ids" nolabel="1" context="{'current_evaluacion_id': active_id}">
+                                <field class="lh-lg w-100" colspan="2" name="usuario_externo_ids" nolabel="1" context="{'actual_evaluacion_id': active_id}">
                                     <tree create="false" editable="bottom">
                                         <field class="lh-m" name="nombre" readonly="1"/>
                                     </tree>

--- a/talent360/evaluaciones/views/evaluaciones_templates.xml
+++ b/talent360/evaluaciones/views/evaluaciones_templates.xml
@@ -23,12 +23,12 @@
         </template>
 
 
-        <template id="encuestas_reporte" name="Reporte: página de reporte genérico">
+        <template id="encuestas_reporte_nom_035" name="Reporte: página de reporte genérico">
             <t t-call="evaluaciones.diseño">
                 <t t-set="limite_registros" t-value="10"/>
                 <div class="o_survey_result mb-5">
                     <t t-call="evaluaciones.encuestas_reporte_header" />
-                    <t t-call="evaluaciones.encuestas_reporte_nom_035" />
+                    <t t-call="evaluaciones.encuestas_reporte_nom_035_body" />
                     <t t-call="evaluaciones.encuestas_reporte_inner" />
                 </div>
             </t>
@@ -39,7 +39,7 @@
                 <t t-set="limite_registros" t-value="10"/>
                 <div class="o_survey_result">
                     <t t-call="evaluaciones.encuestas_reporte_header" />
-                    <t t-call="evaluaciones.encuesta_reporte_clima" />
+                    <t t-call="evaluaciones.encuestas_reporte_clima_body" />
                     <t t-call="evaluaciones.encuestas_reporte_inner" />
                 </div>
             </t>
@@ -68,7 +68,7 @@
         </template>
 
         <!--AQUÍ COMIENZA NOM 035-->
-        <template id="encuestas_reporte_nom_035" name="Reporte: NOM-035">
+        <template id="encuestas_reporte_nom_035_body" name="Reporte: NOM-035">
             <t t-call="evaluaciones.portada_nom035"/>
             <div class="container-fluid row gap-5 justify-content-between g-2">
                 <div class="d-flex flex-row justify-content-between">
@@ -330,7 +330,7 @@
         </template>
 
         <!-- AQUÍ COMIENZA CLIMA -->
-        <template id="encuesta_reporte_clima" name="Reporte de Clima Laboral">
+        <template id="encuestas_reporte_clima_body" name="Reporte de Clima Laboral">
             <t t-call="evaluaciones.portada_clima"/>
             <div class="container-fluid row gap-5 justify-content-between g-2">
                 <div class="d-flex flex-row justify-content-between">
@@ -466,7 +466,7 @@
             </div>
 
 
-            <t t-foreach="evaluacion.generar_datos_reporte_clima_action()['categorias']" t-as="categoria">
+            <t t-foreach="categorias" t-as="categoria">
                 <div class="survey_section container-fluid d-flex align-items-center justify-content-center" style="page-break-inside: avoid; height: 90vh;">
                     <t t-if="'puntuacion' in categoria">
                         <div class="survey_page container-fluid d-flex flex-column align-items-center" style="font-size: 0.9em;">

--- a/talent360/evaluaciones/views/evaluaciones_views.xml
+++ b/talent360/evaluaciones/views/evaluaciones_views.xml
@@ -105,7 +105,8 @@
                 <header>
                     <!-- Generación de reporte de una evaluación-->
                     <button name="evaluacion_action_tree" string="Guardar" type="object" class="btn-primary my-3"/>
-                    <button class="btn btn-primary" name="reporte_generico_action" string="Reporte" type="object" groups="evaluaciones.evaluaciones_cliente_cr_group_user"/>
+                    <button class="btn btn-primary" name="reporte_generico_action" string="Reporte Genérico" type="object" groups="evaluaciones.evaluaciones_cliente_cr_group_user"/>
+                    <button class="btn btn-primary" name="filtros_reporte_action" string="Reporte Personalizado" type="object" groups="evaluaciones.evaluaciones_cliente_cr_group_user"/>
                     <button class="btn btn-primary" name="action_asignar_usuarios_externos" string="Asignar usuarios externos" type="object" groups="evaluaciones.evaluaciones_cliente_cr_group_user"/>
                 </header>
                 <sheet string="Evaluacion de personal">
@@ -131,12 +132,12 @@
                         <field name="incluir_demograficos"/>
                     </group>
                     <group>
-                    <group>
-                        <field name="mensaje"/>
-                    </group>
+                        <group>
+                            <field name="mensaje"/>
+                        </group>
                         <notebook>
                             <page string="Preguntas">
-                                <field class="lh-lg w-100" colspan="2" name="pregunta_ids" readonly="1" nolabel="1" context="{'current_evaluacion_id': active_id}">
+                                <field class="lh-lg w-100" colspan="2" name="pregunta_ids" readonly="1" nolabel="1" context="{'actual_evaluacion_id': active_id}">
                                     <tree editable="bottom" create="0">
                                         <field class="lh-m" name="pregunta_texto" readonly="1"/>
                                         <field class="lh-m" name="tipo" readonly="1"/>
@@ -146,7 +147,7 @@
                                 </field>
                             </page>
                             <page string="Asignados">
-                                <field class="lh-lg w-100" colspan="2" name="usuario_ids" nolabel="1" context="{'current_evaluacion_id': active_id}">
+                                <field class="lh-lg w-100" colspan="2" name="usuario_ids" nolabel="1" context="{'actual_evaluacion_id': active_id}">
                                     <tree editable="bottom">
                                         <field class="lh-m" name="name" readonly="1" string="Nombre del usuario"/>
                                         <button class="btn btn-outline-primary btn-lg px-4 lh-m" name="ver_respuestas_usuario" string="Ver respuestas" type="object"/>
@@ -154,7 +155,7 @@
                                 </field>
                             </page>
                             <page string="Asignados Externos">
-                                <field class="lh-lg w-100" colspan="2" name="usuario_externo_ids" nolabel="1" context="{'current_evaluacion_id': active_id}" options="{'link':false}">
+                                <field class="lh-lg w-100" colspan="2" name="usuario_externo_ids" nolabel="1" context="{'actual_evaluacion_id': active_id}" options="{'link':false}">
                                     <tree editable="top">
                                         <field class="lh-m" name="nombre" readonly="1" string="Nombre del usuario"/>
                                         <button class="btn btn-outline-primary btn-lg px-4 lh-m" name="ver_respuestas_usuario_externo" string="Respuestas" type="object"/>
@@ -329,7 +330,8 @@
                 <field name="tipo" readonly="1"/>
                 <field name="conteo_asignados" readonly="1"/>
                 <field name="porcentaje_respuestas" widget="percentage" readonly="1"/>
-                <button class="btn btn-primary" name="reporte_generico_action" string="Reporte" type="object"/>
+                <button class="btn btn-primary" name="reporte_generico_action" string="Reporte Genérico" type="object" groups="evaluaciones.evaluaciones_cliente_cr_group_user"/>
+                <button class="btn btn-primary" name="filtros_reporte_action" string="Reporte Personalizado" type="object" groups="evaluaciones.evaluaciones_cliente_cr_group_user"/>
             </tree>
         </field>
     </record>
@@ -424,19 +426,19 @@
                         <field name="incluir_demograficos"/>
                     </group>
                     <group>
-                    <group>
-                        <field name="mensaje" placeholder="Escribe aquí tu mensaje de bienvenida"/>
-                    </group>
+                        <group>
+                            <field name="mensaje" placeholder="Escribe aquí tu mensaje de bienvenida"/>
+                        </group>
                         <notebook>
                             <page string="Asignados">
-                                <field class="lh-lg w-100" colspan="2" name="usuario_ids" nolabel="1" context="{'current_evaluacion_id': active_id}">
+                                <field class="lh-lg w-100" colspan="2" name="usuario_ids" nolabel="1" context="{'actual_evaluacion_id': active_id}">
                                     <tree editable="bottom">
                                         <field class="lh-m" name="name" readonly="1" string="Nombre del usuario"/>
                                     </tree>
                                 </field>
                             </page>
                             <page string="Asignados Externos">
-                                <field class="lh-lg w-100" colspan="2" name="usuario_externo_ids" nolabel="1" context="{'current_evaluacion_id': active_id}" options="{'link':false}">
+                                <field class="lh-lg w-100" colspan="2" name="usuario_externo_ids" nolabel="1" context="{'actual_evaluacion_id': active_id}" options="{'link':false}">
                                     <tree create="false" editable="bottom">
                                         <field class="lh-m" name="nombre" readonly="1" string="Nombre del usuario"/>
                                     </tree>

--- a/talent360/evaluaciones/views/evaluaciones_views.xml
+++ b/talent360/evaluaciones/views/evaluaciones_views.xml
@@ -102,6 +102,7 @@
         <field name="arch" type="xml">
             <form create="false" duplicate="0">
                 <field name="tipo" invisible="1" readonly="1"/>
+                <field name="porcentaje_respuestas" invisible="1" readonly="1"/>
                 <header>
                     <!-- Generación de reporte de una evaluación-->
                     <button name="evaluacion_action_tree" string="Guardar" type="object" class="btn-primary my-3"/>

--- a/talent360/evaluaciones/views/wizards_views.xml
+++ b/talent360/evaluaciones/views/wizards_views.xml
@@ -30,7 +30,7 @@
             <form string="Crear Filtros">
                 <field name="filtros_ids">
                     <tree string="Filtros" editable="bottom" create="false" delete="false" edit="true">
-                        <field name="categoria"/>
+                        <field name="categoria" readonly="1"/>
                         <field name="filtro_seleccion_ids" widget="many2many_tags" domain="[('categoria', '=', categoria), ('filtro_original_id', '=', active_id)]" options="{'no_quick_create':True,'no_create_edit':True}"/>
                     </tree>
                 </field>

--- a/talent360/evaluaciones/wizards/__init__.py
+++ b/talent360/evaluaciones/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import asignar_usuarios_exernos_wizard
+from . import crear_filtros

--- a/talent360/evaluaciones/wizards/crear_filtros.py
+++ b/talent360/evaluaciones/wizards/crear_filtros.py
@@ -37,11 +37,11 @@ class Filtro(models.TransientModel):
     _name = "filtro.wizard"
     _rec_name = "categoria"
 
-    categoria = fields.Char()
+    categoria = fields.Char("Filtro")
     categoria_interna = fields.Char()
 
     filtro_seleccion_ids = fields.One2many(
-        "filtro.seleccion.wizard", "filtro_id", string="Selecciones"
+        "filtro.seleccion.wizard", "filtro_id", string="Valores"
     )
 
     crear_filtros_wizard_id = fields.Many2one("crear.filtros.wizard")

--- a/talent360/evaluaciones/wizards/crear_filtros.py
+++ b/talent360/evaluaciones/wizards/crear_filtros.py
@@ -69,7 +69,7 @@ class CrearFiltrosWizard(models.TransientModel):
         Este método se encarga de generar el reporte de evaluación con los filtros seleccionados por el usuario.
 
         :return: acción para abrir el reporte en una nueva pestaña
-        """ 
+        """
 
         evaluacion_id = self.env.context.get("actual_evaluacion_id")
         evaluacion = self.env["evaluacion"].browse(evaluacion_id)
@@ -89,7 +89,7 @@ class CrearFiltrosWizard(models.TransientModel):
 
         :return: query params de los filtros
         """
-        
+
         filtros = []
         for filtro in self.filtros_ids:
             selecciones = filtro.filtro_seleccion_ids.mapped("texto")

--- a/talent360/evaluaciones/wizards/crear_filtros.py
+++ b/talent360/evaluaciones/wizards/crear_filtros.py
@@ -75,7 +75,6 @@ class CrearFiltrosWizard(models.TransientModel):
         evaluacion = self.env["evaluacion"].browse(evaluacion_id)
         query_params = self.crear_filtros_query_params()
 
-        self.unlink()
         return {
             "type": "ir.actions.act_url",
             "url": f"/evaluacion/reporte/{evaluacion.id}?{query_params}",

--- a/talent360/evaluaciones/wizards/crear_filtros.py
+++ b/talent360/evaluaciones/wizards/crear_filtros.py
@@ -1,0 +1,104 @@
+from odoo import fields, models, api, exceptions, _
+
+
+class FiltroSeleccion(models.TransientModel):
+    """
+    Modelo para manejar las selecciones de filtros en el wizard.
+
+    Este modelo se utiliza para manejar las selecciones de filtros en el wizard de creación de filtros.
+
+    :param texto: texto de la selección
+    :param categoria: categoría de la selección, usado para filtrar en UI
+    :param filtro_original_id: id del filtro original, usado para filtrar en UI
+    :param filtro_id: id del filtro al que pertenece la selección
+    """
+
+    _name = "filtro.seleccion.wizard"
+    _rec_name = "texto"
+
+    texto = fields.Char()
+    categoria = fields.Char()
+    filtro_original_id = fields.Integer()
+    filtro_id = fields.Many2one("filtro.wizard", string="Filtro")
+
+
+class Filtro(models.TransientModel):
+    """
+    Modelo para manejar los filtros en el wizard.
+
+    Este modelo se utiliza para manejar los filtros en el wizard de creación de filtros.
+
+    :param categoria: categoría del filtro
+    :param categoria_interna: categoría interna del filtro, se usa para acceder al valor del dato demografico al filtrar
+    :param filtro_seleccion_ids: selecciones del filtro
+    :param crear_filtros_wizard_id: id del wizard al que pertenece el filtro
+    """
+
+    _name = "filtro.wizard"
+    _rec_name = "categoria"
+
+    categoria = fields.Char()
+    categoria_interna = fields.Char()
+
+    filtro_seleccion_ids = fields.One2many(
+        "filtro.seleccion.wizard", "filtro_id", string="Selecciones"
+    )
+
+    crear_filtros_wizard_id = fields.Many2one("crear.filtros.wizard")
+
+
+class CrearFiltrosWizard(models.TransientModel):
+    """
+    Modelo para manejar el wizard de creación de filtros.
+
+    Este modelo se utiliza para manejar el wizard de creación de filtros para el reporte de evaluaciones.
+
+    :param filtros_ids: filtros del wizard
+    """
+
+    _name = "crear.filtros.wizard"
+
+    filtros_ids = fields.One2many(
+        "filtro.wizard", "crear_filtros_wizard_id", string="Filtros"
+    )
+
+    def generar_reporte(self):
+        """
+        Método para generar el reporte de evaluación.
+
+        Este método se encarga de generar el reporte de evaluación con los filtros seleccionados por el usuario.
+
+        :return: acción para abrir el reporte en una nueva pestaña
+        """ 
+
+        evaluacion_id = self.env.context.get("actual_evaluacion_id")
+        evaluacion = self.env["evaluacion"].browse(evaluacion_id)
+        query_params = self.crear_filtros_query_params()
+
+        self.unlink()
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/evaluacion/reporte/{evaluacion.id}?{query_params}",
+            "target": "new",
+        }
+
+    def crear_filtros_query_params(self):
+        """
+        Método para crear los query params de los filtros.
+
+        Este método se encarga de crear los query params de los filtros seleccionados por el usuario.
+
+        :return: query params de los filtros
+        """
+        
+        filtros = []
+        for filtro in self.filtros_ids:
+            selecciones = filtro.filtro_seleccion_ids.mapped("texto")
+            if not selecciones:
+                continue
+
+            selecciones = [f'"{seleccion}"' for seleccion in selecciones]
+            filtro_str = ",".join(selecciones)
+            filtros.append(f'"{filtro.categoria_interna}":[{filtro_str}]')
+
+        return "filtros={" + ",".join(filtros) + "}"


### PR DESCRIPTION
# RF46 Filtrar reportes clima


### Descripción
Como cliente de CR quiero poder filtrar los reportes por área/departamento/dirección, etc.

### Cambios realizados

- Re agrega modelo de wizard de filtros
- Se agregan filtros a generación de datos clima y genérico
- Se corrige obtención de departamento para usuarios externos en reporte clima
- Se corrige cálculo de porcentaje para departamento en reporte clima

### Story Points

XL - 8

### Criterios de aceptación

- [x] El sistema muestra un popup para configurar los filtros de un reporte
- [x] Los filtros permiten agregar múltiples categorías.
- [x] Los filtros pueden incluir varios datos por categoría.
- [x] Se sistema debe mostrar un botón para reporte genérico (sin filtros) y otro para personalizado (Que salga el popup de filtros)

### Evidencias

![Screenshot from 2024-05-20 12-51-01](https://github.com/Black-Dot-2024/cr-blackdot/assets/45676844/4f647cf3-12f7-4de0-a24f-3c0ca6ba34d5)

### Definición de Done

- [x] Cumplimiento de todos los criterios de aceptación
- [x] Pruebas realizadas y aprobadas
- [ ] Integración exitosa a la rama principal (main)
- [x] Actualización de Plan de Valor Ganado
- [x] Actualización de Matriz de Trazabilidad de Requerimientos

### Dependencias

N/A

### Pruebas
Marcar pruebas realizadas. No es obligatorio hacer todas.
- [x] Pruebas Unitarias
- [x] Pruebas de Integración
- [ ] Pruebas de Sistema 

