### PR TITLE
Defecto MBI 47 no se ven colores de circulos en exportar reportes

### DIFF
--- a/talent360/evaluaciones/static/src/scss/survey_templates_results.scss
+++ b/talent360/evaluaciones/static/src/scss/survey_templates_results.scss
@@ -5,7 +5,7 @@
         height: 22px;
         border-radius: 50%;
         display: inline-block;
-        background-color: #ccc; // Color de fondo por defecto para prueba
+        background-color: #ccc; 
     }
 
     .color_circle.excelente { background-color: #2894a7; }
@@ -13,6 +13,12 @@
     .color_circle.regular { background-color: #fcd703; }
     .color_circle.malo { background-color: #fc8803; }
     .color_circle.muy_malo { background-color: #ff4747; }
+
+    .semaforo-item {
+        display: flex;
+        align-items: center;
+        gap: 10px; 
+    }
 
     .page-break {
         page-break-after: always;

--- a/talent360/evaluaciones/static/src/scss/survey_templates_results.scss
+++ b/talent360/evaluaciones/static/src/scss/survey_templates_results.scss
@@ -1,5 +1,19 @@
 @media print {
 
+    .color_circle {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        display: inline-block;
+        background-color: #ccc; // Color de fondo por defecto para prueba
+    }
+
+    .color_circle.excelente { background-color: #2894a7; }
+    .color_circle.bueno { background-color: #5aaf2b; }
+    .color_circle.regular { background-color: #fcd703; }
+    .color_circle.malo { background-color: #fc8803; }
+    .color_circle.muy_malo { background-color: #ff4747; }
+
     .page-break {
         page-break-after: always;
         break-after: always;
@@ -91,7 +105,7 @@
             }
             tbody {
                 tr {
-                  break-inside: avoid;  
+                    break-inside: avoid;  
                 }
                 tr.d-none {
                     display: table-row !important;
@@ -271,6 +285,12 @@
     aspect-ratio: 1;
     width: 22px;
     border-radius: 100%;
+
+    &.excelente { background-color: #2894a7; }
+    &.bueno { background-color: #5aaf2b; }
+    &.regular { background-color: #fcd703; }
+    &.malo { background-color: #fc8803; }
+    &.muy_malo { background-color: #ff4747; }
 }
 
 

--- a/talent360/evaluaciones/static/src/scss/survey_templates_results.scss
+++ b/talent360/evaluaciones/static/src/scss/survey_templates_results.scss
@@ -1,19 +1,4 @@
 @media print {
-
-    .color_circle {
-        width: 22px;
-        height: 22px;
-        border-radius: 50%;
-        display: inline-block;
-        background-color: #ccc; 
-    }
-
-    .color_circle.excelente { background-color: #2894a7; }
-    .color_circle.bueno { background-color: #5aaf2b; }
-    .color_circle.regular { background-color: #fcd703; }
-    .color_circle.malo { background-color: #fc8803; }
-    .color_circle.muy_malo { background-color: #ff4747; }
-
     .semaforo-item {
         display: flex;
         align-items: center;
@@ -286,19 +271,6 @@
     gap: 0.5rem;
     background-color: #dbdbdb;
 }
-
-.color_circle {
-    aspect-ratio: 1;
-    width: 22px;
-    border-radius: 100%;
-
-    &.excelente { background-color: #2894a7; }
-    &.bueno { background-color: #5aaf2b; }
-    &.regular { background-color: #fcd703; }
-    &.malo { background-color: #fc8803; }
-    &.muy_malo { background-color: #ff4747; }
-}
-
 
 @page {
     margin: 0; /* Elimina los márgenes predeterminados de la página */

--- a/talent360/evaluaciones/views/reporte_clima_template.xml
+++ b/talent360/evaluaciones/views/reporte_clima_template.xml
@@ -45,28 +45,41 @@
                 <div class="col survey_section w-100" style="page-break-inside: avoid;">
                     <h4>Semáforo</h4>
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle excelente"></div>
-                        <span class="col">Excelente</span>
-                    </div>
-
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle bueno"></div>
-                        <span class="col">Bueno</span>
-                    </div>
-
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle regular"></div>
-                        <span class="col">Regular</span>
-                    </div>
-
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle malo"></div>
-                        <span class="col">Malo</span>
-                    </div>
-
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle muy_malo"></div>
-                        <span class="col">Muy malo</span>
+                        <!-- Excelente -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#2894a7" />
+                            </svg>
+                            <span>Excelente</span>
+                        </div>
+                        <!-- Bueno -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#5aaf2b" />
+                            </svg>
+                            <span>Bueno</span>
+                        </div>
+                        <!-- Regular -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#fcd703" />
+                            </svg>
+                            <span>Regular</span>
+                        </div>
+                        <!-- Malo -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#fc8803" />
+                            </svg>
+                            <span>Malo</span>
+                        </div>
+                        <!-- Muy malo -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#ff4747" />
+                            </svg>
+                            <span>Muy malo</span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/talent360/evaluaciones/views/reporte_clima_template.xml
+++ b/talent360/evaluaciones/views/reporte_clima_template.xml
@@ -45,25 +45,27 @@
                 <div class="col survey_section w-100" style="page-break-inside: avoid;">
                     <h4>Semáforo</h4>
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #2894a7;"></div>
+                        <div class="color_circle excelente"></div>
                         <span class="col">Excelente</span>
                     </div>
+
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #5aaf2b;"></div>
+                        <div class="color_circle bueno"></div>
                         <span class="col">Bueno</span>
                     </div>
+
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #fcd703;"></div>
+                        <div class="color_circle regular"></div>
                         <span class="col">Regular</span>
                     </div>
 
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #fc8803;"></div>
+                        <div class="color_circle malo"></div>
                         <span class="col">Malo</span>
                     </div>
 
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #ff4747;"></div>
+                        <div class="color_circle muy_malo"></div>
                         <span class="col">Muy malo</span>
                     </div>
                 </div>

--- a/talent360/evaluaciones/views/reporte_nom_035_template.xml
+++ b/talent360/evaluaciones/views/reporte_nom_035_template.xml
@@ -46,28 +46,45 @@
                 <div class="col survey_section w-100" style="page-break-inside: avoid;">
                     <h4>Semáforo de riesgos</h4>
                     <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #ff4747;"/>
-                        <span class="col">Riesgo muy alto</span>
-                    </div>
+                        <!-- Riesgo muy alto -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#ff4747" />
+                            </svg>
+                            <span>Riesgo muy alto</span>
+                        </div>
 
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color:  #fc8803;"/>
-                        <span class="col">Riesgo alto</span>
-                    </div>
+                        <!-- Riesgo alto -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#fc8803" />
+                            </svg>
+                            <span>Riesgo alto</span>
+                        </div>
 
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #fcd703;"/>
-                        <span class="col">Riesgo medio</span>
-                    </div>
+                        <!-- Riesgo medio -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#fcd703" />
+                            </svg>
+                            <span>Riesgo medio</span>
+                        </div>
+                        
+                        <!-- Riesgo bajo -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#5aaf2b" />
+                            </svg>
+                            <span>Riesgo bajo</span>
+                        </div>
 
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #5aaf2b;"/>
-                        <span class="col">Riesgo bajo</span>
-                    </div>
-
-                    <div class="container-fluid row gap-2 align-items-center">
-                        <div class="color_circle" style="background-color: #2894a7;"/>
-                        <span class="col">Riesgo nulo</span>
+                        <!-- Riesgo nulo -->
+                        <div class="semaforo-item">
+                            <svg width="22" height="22" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="11" cy="11" r="11" fill="#2894a7" />
+                            </svg>
+                            <span>Riesgo nulo</span>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Se arregló el ver los círculos de la semaforización en Clima y NOM 035 cuando el reporte de estos es exportado.
Los archivos que cambié fueron 
- talent360\evaluaciones\views\reporte_clima_template.xml
- talent360\evaluaciones\views\reporte_nom_035_template.xml
- talent360\evaluaciones\static\src\scss\survey_templates_results.scss
En los xml se agregó el poder ver los círculos por medio de un svg

Desired behavior after PR is merged:

Se puede ver la semaforización al consultar el reporte y al exportarlo



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
