### PR TITLE
feat/rf30 metrica objetivos

### DIFF
--- a/talent360/evaluaciones/models/objetivo.py
+++ b/talent360/evaluaciones/models/objetivo.py
@@ -201,9 +201,9 @@ class Objetivo(models.Model):
             if not registro.usuario_ids:
                 raise ValidationError(_("Debe asignar al menos un usuario al objetivo"))
             
-    @api.onchange('metrica')
+    @api.onchange("metrica")
     def _onchange_metrica(self):
-        if self.metrica != 'otro':
+        if self.metrica != "otro":
             self.nueva_metrica = False
 
     @api.depends("metrica", "nueva_metrica")
@@ -215,7 +215,7 @@ class Objetivo(models.Model):
         """
 
         for objetivo in self:
-            if objetivo.metrica == 'otro':
+            if objetivo.metrica == "otro":
                 metrica_texto = objetivo.nueva_metrica
             else:
                 metrica_texto = objetivo.metrica
@@ -225,6 +225,6 @@ class Objetivo(models.Model):
     @api.constrains("metrica", "nueva_metrica")
     def _check_nueva_metrica(self):
         for record in self:
-            if record.metrica == 'otro' and (not record.nueva_metrica or record.nueva_metrica.strip() == ''):
+            if record.metrica == "otro" and (not record.nueva_metrica or record.nueva_metrica.strip() == ''):
                 raise ValidationError(("El campo 'Métrica Personalizada' no puede estar vacío."))
                 

--- a/talent360/evaluaciones/models/objetivo.py
+++ b/talent360/evaluaciones/models/objetivo.py
@@ -1,6 +1,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from datetime import date
+from odoo import models
 
 
 class Objetivo(models.Model):
@@ -36,12 +37,20 @@ class Objetivo(models.Model):
         [
             ("porcentaje", "Porcentaje"),
             ("monto", "Monto"),
+            ("otro", "Otro")
         ],
         default="porcentaje",
         required=True,
         string="Métrica",
         help="¿Cómo se medirá el objetivo? Ej. En porcentaje o en monto",
     )
+    nueva_metrica = fields.Char(string="Nueva Métrica", help="Ingrese una nueva métrica si seleccionó 'Otro'", size=20)
+    metrica_mostrar = fields.Char(
+        string="Métrica", compute="_compute_metrica_mostrar", store="True", size=20
+    )
+
+
+   
 
     tipo = fields.Selection(
         [
@@ -192,4 +201,24 @@ class Objetivo(models.Model):
             if not registro.usuario_ids:
                 raise ValidationError(_("Debe asignar al menos un usuario al objetivo"))
             
-    
+    @api.onchange('metrica')
+    def _onchange_metrica(self):
+        if self.metrica != 'otro':
+            self.nueva_metrica = False
+
+    @api.depends("metrica", "nueva_metrica")
+    def _compute_metrica_mostrar(self):
+        """
+        Método para calcular la respuesta a mostrar en la vista.
+
+        :return: Respuesta a mostrar en la vista
+        """
+
+        for objetivo in self:
+            if objetivo.metrica == 'otro':
+                metrica_texto = objetivo.nueva_metrica
+            else:
+                metrica_texto = objetivo.metrica
+
+        objetivo.metrica_mostrar = metrica_texto
+            

--- a/talent360/evaluaciones/models/objetivo.py
+++ b/talent360/evaluaciones/models/objetivo.py
@@ -221,4 +221,10 @@ class Objetivo(models.Model):
                 metrica_texto = objetivo.metrica
 
         objetivo.metrica_mostrar = metrica_texto
-            
+
+    @api.constrains("metrica", "nueva_metrica")
+    def _check_nueva_metrica(self):
+        for record in self:
+            if record.metrica == 'otro' and (not record.nueva_metrica or record.nueva_metrica.strip() == ''):
+                raise ValidationError(("El campo 'Métrica Personalizada' no puede estar vacío."))
+                

--- a/talent360/evaluaciones/views/objetivos_views.xml
+++ b/talent360/evaluaciones/views/objetivos_views.xml
@@ -11,6 +11,7 @@
                 <field name="tipo" string="Tipo"/>
                 <field name="estado" string="Estado"/>
                 <field name="peso" string="Peso"/>
+                <field name="metrica_mostrar" string="Métrica"/>
                 <field name="piso_minimo" string="Piso Mínimo"/>
                 <field name="piso_maximo" string="Piso Máximo"/>
             </tree>
@@ -103,7 +104,9 @@
                                 <div class="row">
                                     <div class="col-md-6">
                                         <label for="metrica" string="Métrica" />
-                                        <field name="metrica" />
+                                        <field name="metrica" options="{'no_create': False, 'no_open': True}" />
+                                        <field name="nueva_metrica" invisible="metrica != 'otro'" placeholder="Métrica Personalizada"/>
+
                                         <br />
                                         <label for="orden" string="Orden" />
                                         <field name="orden" />


### PR DESCRIPTION
# RF 30 Elegir unidad de medida para cada objetivo

### Descripción
Como cliente de CR quiero seleccionar una unidad de medida personalizable para cada objetivo, para medir correctamente el avance.

### Cambios realizados

- Creación de opción Otro en el select
- Funcionalidad para guardar el valor de la metrica personalizada en el espacio de la métrica
- Mostrar la métrica seleccionada en la vista tree de objetivos

### Story Points

S - 2

### Criterios de aceptación

- [X] El sistema muestra catálogo de unidades de medida predeterminadas
- [X] El sistema permite crear unidad de medida personalizada

### Evidencias

- Evidencia 1 
![image](https://github.com/Black-Dot-2024/cr-blackdot/assets/89052608/0fb3cca3-72d8-4582-b2c1-7f26f90443d4)

- Evidencia 2 
![image](https://github.com/Black-Dot-2024/cr-blackdot/assets/89052608/9ce4364a-7bb6-4928-80cd-f9553161d1c7)


### Definición de Done

- [ X] Cumplimiento de todos los criterios de aceptación
- [ X] Pruebas realizadas y aprobadas
- [ ] Integración exitosa a la rama principal (main)
- [X] Actualización de Plan de Valor Ganado
- [X] Actualización de Matriz de Trazabilidad de Requerimientos

### Dependencias

Que exista la vista form de objetivo

### Pruebas
Marcar pruebas realizadas. No es obligatorio hacer todas.
- [ ] Pruebas Unitarias
- [X] Pruebas de Integración
- [ ] Pruebas de Sistema 

